### PR TITLE
Fix: Use usePathname for active navigation link styling

### DIFF
--- a/src/app/(components)/navbar.tsx
+++ b/src/app/(components)/navbar.tsx
@@ -1,7 +1,8 @@
+"use client";
 import styles from './navbar.module.css'
 import Image from "next/image";
 import Link from "next/link";
-import { headers} from "next/headers";
+import { usePathname } from "next/navigation";
 import { Sacramento, Montserrat } from "next/font/google";
 
 // @ts-ignore
@@ -10,9 +11,9 @@ const montserrat  = Montserrat({weight:['400'],subsets: ['latin']})
 export default function Navbar () {
 
     // const currentPath = typeof window !== 'undefined' ? window.location.pathname : '';
-    // const currentPath  = usePathname();
-    const headerList = headers();
-    const currentPath = headerList.get('x-invoke-path');
+    const currentPath  = usePathname();
+    // const headerList = headers();
+    // const currentPath = headerList.get('x-invoke-path');
     //@ts-ignore
     return (
         <div className={styles.navbarLayout}>


### PR DESCRIPTION
I replaced header-based path detection with the usePathname hook in the Navbar component. This ensures consistent behavior for determining the active link, especially in environments like Vercel where header information might differ from local development.

The usePathname hook is the recommended Next.js approach for accessing the current path in App Router components. I added "use client" directive as required by the hook.

I confirmed that the active link (bolded text)
functions correctly with this change.